### PR TITLE
Add ability to AB test sortable against google.

### DIFF
--- a/ads/sortable.js
+++ b/ads/sortable.js
@@ -25,12 +25,13 @@ import {adsense} from './google/adsense';
 export function sortable(global, data) {
   /**
    * For A/B testing our tags against doubleclick or adsense in AMP ads.
+   * See https://github.com/ampproject/amphtml/blob/master/ads/sortable.md for examples.
    */
-  if(data.ab && data.ab === 'doubleclick' && data.ab_pct && Math.random()*100 < data.ab_pct) {
+  if(data.abType && data.abType === 'doubleclick' && data.abPct && Math.random()*100 < data.abPct) {
     doubleclick(global, data);
     return;
   } 
-  if(data.ab && data.ab === 'adsense' && data.ab_pct && Math.random()*100 < data.ab_pct) {
+  if(data.abType && data.abType === 'adsense' && data.abPct && Math.random()*100 < data.abPct) {
     adsense(global, data);
     return;
   } 

--- a/ads/sortable.js
+++ b/ads/sortable.js
@@ -27,11 +27,11 @@ export function sortable(global, data) {
    * For A/B testing our tags against doubleclick or adsense in AMP ads.
    * See https://github.com/ampproject/amphtml/blob/master/ads/sortable.md for examples.
    */
-  if(data.abType && data.abType === 'doubleclick' && data.abPct && Math.random()*100 < data.abPct) {
+  if(data.abType && data.abType === 'doubleclick' && data.abPct && Math.random()*100 < parseInt(data.abPct, 10)) {
     doubleclick(global, data);
     return;
   } 
-  if(data.abType && data.abType === 'adsense' && data.abPct && Math.random()*100 < data.abPct) {
+  if(data.abType && data.abType === 'adsense' && data.abPct && Math.random()*100 < parseInt(data.abPct, 10)) {
     adsense(global, data);
     return;
   } 

--- a/ads/sortable.js
+++ b/ads/sortable.js
@@ -15,6 +15,8 @@
  */
 
 import {loadScript, validateData} from '../3p/3p';
+import {doubleclick} from './google/doubleclick';
+import {adsense} from './google/adsense';
 
 /**
  * @param {!Window} global
@@ -29,6 +31,17 @@ export function sortable(global, data) {
   ad.setAttribute('data-ad-name', data.name);
   ad.setAttribute('data-ad-size', data.width + 'x' + data.height);
   slot.appendChild(ad);
+  /**
+   * For A/B testing our tags against doubleclick or adsense in AMP ads.
+   */
+  if(data.ab && data.ab === 'doubleclick' && data.ab_pct && Math.random()*100 < data.ab_pct) {
+    doubleclick(global, data);
+    return;
+  } 
+  if(data.ab && data.ab === 'adsense' && data.ab_pct && Math.random()*100 < data.ab_pct) {
+    adsense(global, data);
+    return;
+  } 
   loadScript(global, 'https://tags-cdn.deployads.com/a/'
       + encodeURIComponent(data.site) + '.js');
 }

--- a/ads/sortable.js
+++ b/ads/sortable.js
@@ -23,14 +23,6 @@ import {adsense} from './google/adsense';
  * @param {!Object} data
  */
 export function sortable(global, data) {
-  validateData(data, ['site', 'name']);
-
-  const slot = global.document.getElementById('c');
-  const ad = global.document.createElement('div');
-  ad.className = 'ad-tag';
-  ad.setAttribute('data-ad-name', data.name);
-  ad.setAttribute('data-ad-size', data.width + 'x' + data.height);
-  slot.appendChild(ad);
   /**
    * For A/B testing our tags against doubleclick or adsense in AMP ads.
    */
@@ -42,6 +34,14 @@ export function sortable(global, data) {
     adsense(global, data);
     return;
   } 
+
+  validateData(data, ['site', 'name']);
+  const slot = global.document.getElementById('c');
+  const ad = global.document.createElement('div');
+  ad.className = 'ad-tag';
+  ad.setAttribute('data-ad-name', data.name);
+  ad.setAttribute('data-ad-size', data.width + 'x' + data.height);
+  slot.appendChild(ad);
   loadScript(global, 'https://tags-cdn.deployads.com/a/'
       + encodeURIComponent(data.site) + '.js');
 }

--- a/ads/sortable.md
+++ b/ads/sortable.md
@@ -31,6 +31,32 @@ limitations under the License.
       data-site="ampproject.org">
   </amp-ad>
 ```
+### A/B testing
+```html
+  <amp-ad width="300" height="250"
+      type="sortable"
+      data-name="medrec"
+      data-site="ampproject.org"
+      data-ab-type="doubleclick"
+      data-ab-pct="50"
+      data-slot="/1966186/Pub_ampproject.org_300x250">
+    <div placeholder></div>
+    <div fallback></div>
+  </amp-ad>
+
+  <amp-ad width="300" height="250"
+      type="sortable"
+      data-name="medrec"
+      data-site="ampproject.org"
+      data-ab-type="adsense"
+      data-ab-pct="50"
+      data-ad-client="ca-pub-3693684048097240"
+      data-ad-slot="3616725052"
+      data-ad-format="auto">
+    <div placeholder></div>
+    <div fallback></div>
+  </amp-ad>
+```
 
 ## Configuration
 
@@ -44,5 +70,10 @@ __Required:__
 
 `type` - always set to "sortable"
  
+__Optional:__
+
+`data-ab-type` - for A/B testing Sortable against other services. Either 'adsense' or 'doubleclick'.
+`data-ab-pct` - percent likelihood that the alternate tags will be run instead of Sortable's.
 
 No explicit configuration is needed for a given sortable amp-ad, though each site must be set up beforehand with [Sortable](http://sortable.com). The site name `ampproject.org` can be used for testing. Note that only the two examples above will show an ad properly.
+for A/B testing, ad slots must have attributes compliant with the services that are being tested against Sortable. See the examples above.

--- a/ads/sortable.md
+++ b/ads/sortable.md
@@ -40,8 +40,6 @@ limitations under the License.
       data-ab-type="doubleclick"
       data-ab-pct="50"
       data-slot="/1966186/Pub_ampproject.org_300x250">
-    <div placeholder></div>
-    <div fallback></div>
   </amp-ad>
 
   <amp-ad width="300" height="250"
@@ -53,8 +51,6 @@ limitations under the License.
       data-ad-client="ca-pub-3693684048097240"
       data-ad-slot="3616725052"
       data-ad-format="auto">
-    <div placeholder></div>
-    <div fallback></div>
   </amp-ad>
 ```
 


### PR DESCRIPTION
We can now AB test sortable against doubleclick and adsense tags.
Use data-ab to specify test type, and data-ab_pct to specify probability
of using alternate tags.